### PR TITLE
Add a CC'05 paper

### DIFF
--- a/biblio.html
+++ b/biblio.html
@@ -55,6 +55,15 @@ Benjamin Livshits, John Whaley, and MS&nbsp;Lam.
 
 </p>
 
+<p><a name="Xue2005"></a>
+
+ Jingling Xue, and Phung Hua Nguyen.
+ Completeness Analysis for Incomplete Object-Oriented Programs.
+ In <em>CC</em>, 2005.
+[&nbsp;<a href="soundinessrefs_bib.html#Xue2005">bib</a>&nbsp;]
+
+</p>
+
 <p><a name="Smaragdakis2007"></a>
 
 Yannis Smaragdakis and Christoph Csallner.

--- a/index.html
+++ b/index.html
@@ -315,6 +315,7 @@
       <li> Bravenboer, M. and Smaragdakis, Y. 2009. Strictly declarative specification of sophisticated points-to analyses. ACM SIGPLAN Notices (Oct. 2009), 243.
       <li> Smaragdakis, Y. and Csallner, C. 2007. Combining Static and Dynamic Reasoning for Bug Detection. Tests and Proofs (2007).
       <li> Lhoták, O. 2007. Comparing call graphs. PASTE (2007).
+      <li> Xue, J. and Nguyen, PH. 2005. Completeness Analysis for Incomplete Object-Oriented Programs. CC (2005).
       <li> Livshits, B., Whaley, J. and Lam, M. 2005. Reflection analysis for Java. Programming Languages and Systems. 0326227 (2005).
       <li> Flanagan, Cormac and Leino, K.R.M., Lillibridge, M., Nelson, G., Saxe, J.B. and Stata, R. 2002. Extended Static Checking for Java. PLDI (2002).
 

--- a/soundinessrefs.bib
+++ b/soundinessrefs.bib
@@ -15,6 +15,15 @@ title = {{Reflection analysis for Java}},
 url = {http://link.springer.com/chapter/10.1007/11575467\_11},
 year = {2005}
 }
+
+@inproceedings{Xue2005,
+  author = {Xue, Jingling and Nguyen, Phung Hua},
+  booktitle = {CC},
+  mendeley-groups = {Soundiness},
+  title = {{Completeness Analysis for Incomplete Object-Oriented Programs}},
+  year = {2005}
+}
+
 @inproceedings{Lhotak2007,
 author = {Lhot\'{a}k, Ondej},
 booktitle = {PASTE},

--- a/soundinessrefs_bib.html
+++ b/soundinessrefs_bib.html
@@ -21,6 +21,16 @@
 }
 </pre>
 
+<a name="Xue2005"></a><pre>
+@inproceedings{<a href="soundinessrefs.html#Xue2005">Xue2005</a>,
+  author = {Xue, Jingling and Nguyen, Phung Hua},
+  booktitle = {CC},
+  mendeley-groups = {Soundiness},
+  title = {{Completeness Analysis for Incomplete Object-Oriented Programs}},
+  year = {2005}
+}
+</pre>
+
 <a name="Lhotak2007"></a><pre>
 @inproceedings{<a href="soundinessrefs.html#Lhotak2007">Lhotak2007</a>,
   author = {Lhot\'{a}k, Ondej},


### PR DESCRIPTION
Hi All,

We think this earlier paper (CC'05) from our group is relevant and hope it will be included in
the Soundiness Web Page. 
http://www.cse.unsw.edu.au/~jingling/papers/cc05.pdf

This paper demonstrates how to analyse soundly a Java program in the presence of dynamic class loading. The idea is to identify the “incomplete” points-to sets and also “incomplete” pointed-by sets in the presence of dynamic class loading. As one client application, the paper demonstrates how to
find more “complete” and mono call sites than the prior work then.

Thanks
