### PR TITLE
Add TSE'13 paper

### DIFF
--- a/biblio.html
+++ b/biblio.html
@@ -45,6 +45,15 @@ K.&nbsp;Rustan&nbsp;M. Flanagan, Cormac and Leino, Mark Lillibridge, Greg Nelson
 
 </p>
 
+<p><a name="Xue2005"></a>
+
+Jingling Xue and Phung&nbsp;Hua Nguyen.
+ Completeness Analysis for Incomplete Object-Oriented Programs.
+ In <em>CC</em>, 2005.
+[&nbsp;<a href="soundinessrefs_bib.html#Xue2005">bib</a>&nbsp;]
+
+</p>
+
 <p><a name="Livshits"></a>
 
 Benjamin Livshits, John Whaley, and MS&nbsp;Lam.
@@ -52,15 +61,6 @@ Benjamin Livshits, John Whaley, and MS&nbsp;Lam.
  <em>Programming Languages and Systems</em>, (0326227), 2005.
 [&nbsp;<a href="soundinessrefs_bib.html#Livshits">bib</a>&nbsp;| 
 <a href="http://link.springer.com/chapter/10.1007/11575467\_11">http</a>&nbsp;]
-
-</p>
-
-<p><a name="Xue2005"></a>
-
- Jingling Xue, and Phung Hua Nguyen.
- Completeness Analysis for Incomplete Object-Oriented Programs.
- In <em>CC</em>, 2005.
-[&nbsp;<a href="soundinessrefs_bib.html#Xue2005">bib</a>&nbsp;]
 
 </p>
 
@@ -97,7 +97,7 @@ Gregor Richards, Christian Hammer, and Brian Burg.
 Eric Bodden, Andreas Sewe, Jan Sinschek, Hela Oueslati, and Mira Mezini.
  Taming Reflection Aiding Static Analysis in the Presence of
   Reflection and Custom Class Loaders.
- In <em>ICSE</em>, number Connection c, pages 241--250, 2011.
+ In <em>ICSE</em>, number Connection c, pages 241-250, 2011.
 [&nbsp;<a href="soundinessrefs_bib.html#Bodden">bib</a>&nbsp;]
 
 </p>
@@ -112,12 +112,23 @@ Gregor Richards.
 
 </p>
 
+<p><a name="soares:6175911"></a>
+
+G.&nbsp;Soares, R.&nbsp;Gheyi, and T.&nbsp;Massoni.
+ Automated behavioral testing of refactoring engines.
+ <em>Software Engineering, IEEE Transactions on</em>, 39(2):147-162, Feb
+  2013.
+[&nbsp;<a href="soundinessrefs_bib.html#soares:6175911">bib</a>&nbsp;| 
+<a href="http://dx.doi.org/10.1109/TSE.2012.19">DOI</a>&nbsp;]
+
+</p>
+
 <p><a name="Feldthaus2013"></a>
 
 Asger Feldthaus, Max Sch&auml;fer, Manu Sridharan, Julian Dolby, and Frank Tip.
  Efficient Construction of Approximate Call Graphs for JavaScript IDE
   Services.
- In <em>ICSE</em>, pages 752--761, 2013.
+ In <em>ICSE</em>, pages 752-761, 2013.
 [&nbsp;<a href="soundinessrefs_bib.html#Feldthaus2013">bib</a>&nbsp;]
 
 </p>
@@ -170,7 +181,6 @@ Yue Li, Tian Tan, and Jingling Xue.
 [&nbsp;<a href="soundinessrefs_bib.html#Li2015">bib</a>&nbsp;]
 
 </p>
-
       </section>
     </div>
 

--- a/index.html
+++ b/index.html
@@ -310,7 +310,8 @@
       <li> Li, Y., Tan, T., Sui, Y. and Xue, J. Self-Inferencing Reflection Resolution for Java. ECOOP (2014).
       <li> Feldthaus, A., Schäfer, M., Sridharan, M., Dolby, J. and Tip, F. 2013. Efficient Construction of Approximate Call Graphs for JavaScript IDE Services. ICSE (2013), 752–761.
       <li> Richards, G. 2012. Eval Begone ! Semi-Automated Removal of Eval from JavaScript Programs. OOPSLA (2012).
-      <li> Bodden, E., Sewe, A., Sinschek, J., Oueslati, H. and Mezini, M. 2011. Taming Reflection Aiding Static Analysis in the Presence of Reflection and Custom Class Loaders. ICSE (2011), 241–250.
+      <li> G. Soares, R. Gheyi, and T. Massoni. Automated behavioral testing of refactoring engines. IEEE TSE (2013).
+	  <li> Bodden, E., Sewe, A., Sinschek, J., Oueslati, H. and Mezini, M. 2011. Taming Reflection Aiding Static Analysis in the Presence of Reflection and Custom Class Loaders. ICSE (2011), 241–250.
       <li> Richards, G., Hammer, C. and Burg, B. 2011. The Eval that men do: A large-scale study of the use of eval in JavaScript applications. ECOOP (2011).
       <li> Bravenboer, M. and Smaragdakis, Y. 2009. Strictly declarative specification of sophisticated points-to analyses. ACM SIGPLAN Notices (Oct. 2009), 243.
       <li> Smaragdakis, Y. and Csallner, C. 2007. Combining Static and Dynamic Reasoning for Bug Detection. Tests and Proofs (2007).

--- a/soundinessrefs.bib
+++ b/soundinessrefs.bib
@@ -119,3 +119,17 @@ mendeley-groups = {Soundiness},
 title = {{Effective Soundness-Guided Reflection Analysis}},
 year = {2015}
 }
+
+
+@ARTICLE{soares:6175911, 
+author={Soares, G. and Gheyi, R. and Massoni, T.}, 
+journal={Software Engineering, IEEE Transactions on}, 
+title={Automated Behavioral Testing of Refactoring Engines}, 
+year={2013}, 
+volume={39}, 
+number={2}, 
+pages={147-162}, 
+keywords={Java;automatic programming;program testing;JastAdd refactoring tools;Java program generator;Java refactoring engines;SafeRefactor;automated behavioral testing;compilation errors;refactoring engine developers;refactoring transformation;Automatic programming;Computer bugs;Engines;Java;Metals;Testing;Unified modeling language;Refactoring;automated testing;program generation}, 
+doi={10.1109/TSE.2012.19}, 
+ISSN={0098-5589}, 
+month={Feb},}

--- a/soundinessrefs.bib
+++ b/soundinessrefs.bib
@@ -119,8 +119,6 @@ mendeley-groups = {Soundiness},
 title = {{Effective Soundness-Guided Reflection Analysis}},
 year = {2015}
 }
-<<<<<<< HEAD
-
 
 @ARTICLE{soares:6175911, 
 author={Soares, G. and Gheyi, R. and Massoni, T.}, 
@@ -134,7 +132,7 @@ keywords={Java;automatic programming;program testing;JastAdd refactoring tools;J
 doi={10.1109/TSE.2012.19}, 
 ISSN={0098-5589}, 
 month={Feb},}
-=======
+
 @inproceedings{ChristakisMuellerWuestholz2012,
   author    = {Christakis, Maria and M{\"u}ller, Peter and
                   W{\"u}stholz, Valentin},
@@ -147,4 +145,4 @@ month={Feb},}
   pages     = {132--146},
   publisher = {Springer}
 }
->>>>>>> upstream/master
+

--- a/soundinessrefs_bib.html
+++ b/soundinessrefs_bib.html
@@ -158,3 +158,20 @@
   year = {2015}
 }
 </pre>
+
+<a name="soares:6175911"></a><pre>
+@article{<a href="soundinessrefs.html#soares:6175911">soares:6175911</a>,
+  author = {Soares, G. and Gheyi, R. and Massoni, T.},
+  journal = {Software Engineering, IEEE Transactions on},
+  title = {Automated Behavioral Testing of Refactoring Engines},
+  year = {2013},
+  volume = {39},
+  number = {2},
+  pages = {147-162},
+  keywords = {Java;automatic programming;program testing;JastAdd refactoring tools;Java program generator;Java refactoring engines;SafeRefactor;automated behavioral testing;compilation errors;refactoring engine developers;refactoring transformation;Automatic programming;Computer bugs;Engines;Java;Metals;Testing;Unified modeling language;Refactoring;automated testing;program generation},
+  doi = {10.1109/TSE.2012.19},
+  issn = {0098-5589},
+  month = {Feb}
+}
+</pre>
+


### PR DESCRIPTION
Hi All,

We think this article from our group is relevant and hope it will be included in
the Soundiness Web Page. 
https://sites.google.com/a/computacao.ufcg.edu.br/spg/publications/tse12.pdf?attredirects=0

This paper presents a technique for testing of refactoring engines. The idea is to check the soundiness of these tools for a give scope of Java elements. This technique was useful to find a number of bugs in refactoring tools from industry and academia and help developers and researchers to improve their tools.

Thanks
Gustavo
