### PR TITLE
Add an ECOOP'16 paper

### DIFF
--- a/biblio.html
+++ b/biblio.html
@@ -182,6 +182,15 @@ Yue Li, Tian Tan, and Jingling Xue.
 
 </p>
 
+<p><a name="Li2016"></a>
+
+Yue Li, Tian Tan, Yifei Zhang and Jingling Xue.
+ Program Tailoring: Slicing by Sequential Criteria.
+ In <em>ECOOP</em>, 2016.
+[&nbsp;<a href="soundinessrefs_bib.html#Li2016">bib</a>&nbsp;]
+
+</p>
+
 <p><a name="Christakis"></a>
 
 Maria Christakis, Peter M&uuml;ller, and Valentin W&uuml;stholz.

--- a/index.html
+++ b/index.html
@@ -304,6 +304,7 @@
       </style>
 
       <ul class="biblio">
+      <li> Li, Y., Tan, T., Zhang, Y. and Xue, J. Program Tailoring: Slicing by Sequential Criteria. ECOOP (2016).</li>
       <li> Li, Y., Tan, T. and Xue, J. Effective Soundness-Guided Reflection Analysis. SAS (2015).</li>
       <li> Smaragdakis, Y. and Kastrinis, G. and Balatsouras, G. and Bravenboer, M. More Sound Static Handling of Java Reflection, 2014.</li>
       <li> Christakis, M., Müller, P. and Wüstholz, V. An Experimental Evaluation of Deliberate Unsoundness in a Static Program Analyzer. VMCAI (2015).

--- a/soundinessrefs.bib
+++ b/soundinessrefs.bib
@@ -120,6 +120,14 @@ title = {{Effective Soundness-Guided Reflection Analysis}},
 year = {2015}
 }
 
+@inproceedings{Li2016,
+author = {Li, Yue and Tan, Tian and Zhang, Yifei and Xue, Jingling},
+booktitle = {ECOOP},
+mendeley-groups = {Soundiness},
+title = {{Program Tailoring: Slicing by Sequential Criteria}},
+year = {2016}
+}
+
 @ARTICLE{soares:6175911, 
 author={Soares, G. and Gheyi, R. and Massoni, T.}, 
 journal={Software Engineering, IEEE Transactions on}, 

--- a/soundinessrefs_bib.html
+++ b/soundinessrefs_bib.html
@@ -159,6 +159,16 @@
 }
 </pre>
 
+<a name="Li2016"></a><pre>
+@inproceedings{<a href="soundinessrefs.html#Li2016">Li2015</a>,
+  author = {Li, Yue and Tan, Tian and Zhang, Yifei and Xue, Jingling},
+  booktitle = {ECOOP},
+  mendeley-groups = {Soundiness},
+  title = {{Program Tailoring: Slicing by Sequential Criteria}},
+  year = {2016}
+}
+</pre>
+
 <a name="soares:6175911"></a><pre>
 @article{<a href="soundinessrefs.html#soares:6175911">soares:6175911</a>,
   author = {Soares, G. and Gheyi, R. and Massoni, T.},


### PR DESCRIPTION
Hi all,

Do you mind including our new ECOOP'16 paper titled "Program Tailoring: Slicing by Sequential Criteria"
http://www.cse.unsw.edu.au/~yueli/papers/ecoop16.pdf
on your soundiness web site?

Inspired by your "soundiness manifesto", this paper proposes a soundy analysis to help some client applications such as program debugging and understanding and program analysis.
Please see the "soundiness" paragraph in Section 1.1 in the paper to further understand our soundiness.

Thanks.
