### PR TITLE
Remove buffer overrun from unsoundly modeled semantics

### DIFF
--- a/generator.html
+++ b/generator.html
@@ -37,7 +37,6 @@
 				"features" : [
 					"memory allocations represent unshared blocks",
 					"pointer creation (0x12345678 cast to int*)",
-					"lack of buffer overruns",
 					"setJmp and longJmp",
 					"negative stack references",
 					"integer overflow",

--- a/index.html
+++ b/index.html
@@ -23,7 +23,6 @@
                                 "features" : [
                                         "memory allocations can represent shared blocks",
                                         "pointer creation (0x12345678 cast to int*)",
-                                        "buffer overruns not assumed impossible",
                                         "setJmp and longJmp",
                                         "negative stack references",
                                         "integer overflow",


### PR DESCRIPTION
Immediately creating a pull request this time instead of an issue first, hope that's alright.

For C/C++, "assuming that buffer overrun is impossible" is listed as an unsound behavior for points-to analyses. Although I agree that points-to analyses assume that the program does not exhibit undefined behavior by accessing memory out of bounds, I do not think this should be regarded as "unsound" modeling similarly to the others on the list. Points-to sets are often used to determine the valid set of objects a pointer may refer to in security applications, which is then somehow enforced at run time. If a "sound" points-to analysis is defined as an analysis that considers buffer overruns possible, this entire use case for points-to analysis dissappears. In fact, the security community is increasingly recognizing the soundness problems of most points-to analyses since they lead to false positives, and coming up with various fixes (e.g., CryptoMPK at S&P'22). The "unsound" modeling of buffer overruns is very much an intended effect of points-to analysis in my research area, which entirely underpins it its usefulness.

It may be that this is a terminology/definition/semantics issue that I am not aware of. I was just wondering if there was any reason to include buffer overruns in this list? Happy to close the pull request if I'm missing some use cases where they would be useful to model.
