### PR TITLE
Add SOAP '23 paper on setjmp/longjmp

### DIFF
--- a/soundinessrefs.bib
+++ b/soundinessrefs.bib
@@ -146,3 +146,23 @@ month={Feb},}
   publisher = {Springer}
 }
 
+@inproceedings{DBLP:conf/pldi/0007EVSS23,
+  author       = {Michael Schwarz and
+                  Julian Erhard and
+                  Vesal Vojdani and
+                  Simmo Saan and
+                  Helmut Seidl},
+  editor       = {Pietro Ferrara and
+                  Liana Hadarean},
+  title        = {When Long Jumps Fall Short: Control-Flow Tracking and Misuse Detection
+                  for Non-local Jumps in {C}},
+  booktitle    = {SOAP},
+  pages        = {20--26},
+  publisher    = {{ACM}},
+  year         = {2023},
+  url          = {https://doi.org/10.1145/3589250.3596140},
+  doi          = {10.1145/3589250.3596140},
+  timestamp    = {Sat, 30 Sep 2023 09:54:48 +0200},
+  biburl       = {https://dblp.org/rec/conf/pldi/0007EVSS23.bib},
+  bibsource    = {dblp computer science bibliography, https://dblp.org}
+}


### PR DESCRIPTION
In part inspired by the manifesto, we took another look at setjmp / longjmp, which is one the features on the checklist, and came up with a static analysis for it. 
We wrote a SOAP paper about the analysis (SOAP is a workshop co-located with PLDI): https://dl.acm.org/doi/10.1145/3589250.3596140

In case the bibliography is still maintained, we think it might make for a nice addition :) 