### PR TITLE
Add ACM TOPS 2021 paper on eval

### DIFF
--- a/soundinessrefs.bib
+++ b/soundinessrefs.bib
@@ -166,3 +166,20 @@ month={Feb},}
   biburl       = {https://dblp.org/rec/conf/pldi/0007EVSS23.bib},
   bibsource    = {dblp computer science bibliography, https://dblp.org}
 }
+
+@article{ArceriM21,
+  author       = {Vincenzo Arceri and
+                  Isabella Mastroeni},
+  title        = {Analyzing Dynamic Code: {A} Sound Abstract Interpreter for \emph{Evil}
+                  Eval},
+  journal      = {{ACM} Trans. Priv. Secur.},
+  volume       = {24},
+  number       = {2},
+  pages        = {10:1--10:38},
+  year         = {2021},
+  url          = {https://doi.org/10.1145/3426470},
+  doi          = {10.1145/3426470},
+  timestamp    = {Sat, 08 Jan 2022 02:22:54 +0100},
+  biburl       = {https://dblp.org/rec/journals/tissec/ArceriM21.bib},
+  bibsource    = {dblp computer science bibliography, https://dblp.org}
+}


### PR DESCRIPTION
In this paper (partially inspired by the manifesto) we propose an abstract interpretation-based approach for analyzing eval. We focused on three key issues: designing a string abstract domain to capture possible string values before eval execution (using regular languages for string abstraction), performing string executability analysis to approximate executable code (using CFGs for code abstraction), and recursively calling the abstract interpreter for approximated code. 

Link: https://dl.acm.org/doi/pdf/10.1145/3426470